### PR TITLE
Lower deployment target from Tahoe (26.4) to Sequoia (15.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  pull_request:
   workflow_dispatch:
     inputs:
       version:
@@ -11,8 +12,14 @@ on:
         required: false
         default: ''
 
+# Cancel in-progress runs on the same branch/PR when a new commit lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build:
@@ -36,6 +43,7 @@ jobs:
         run: brew install xcodegen
 
       - name: Import Developer ID cert
+        if: github.event_name != 'pull_request'
         env:
           CERT_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12 }}
           CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
@@ -53,6 +61,7 @@ jobs:
           security list-keychain -d user -s "$KEYCHAIN" login.keychain
 
       - name: Populate ExportOptions.plist team ID
+        if: github.event_name != 'pull_request'
         run: |
           /usr/libexec/PlistBuddy \
               -c "Set :teamID ${{ secrets.APPLE_TEAM_ID }}" \
@@ -83,10 +92,12 @@ jobs:
           echo "hister_version=$V" >> "$GITHUB_OUTPUT"
           echo "==> HISTER_VERSION=$V"
 
-      - name: Build, sign, notarize
+      # On PRs: unsigned ad-hoc build only (no secrets, no notary).
+      # On push/dispatch: signed + notarized.
+      - name: Build
         env:
-          CODE_SIGN_IDENTITY: Developer ID Application
-          NOTARIZE: '1'
+          CODE_SIGN_IDENTITY: ${{ github.event_name == 'pull_request' && '-' || 'Developer ID Application' }}
+          NOTARIZE: ${{ github.event_name == 'pull_request' && '0' || '1' }}
           APPLE_NOTARY_USER: ${{ secrets.APPLE_NOTARY_USER }}
           APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -94,6 +105,7 @@ jobs:
         run: scripts/build.sh
 
       - name: Release notes
+        if: github.event_name == 'push'
         id: notes
         run: |
           UPSTREAM_SHA="$(git -C vendor/hister rev-parse HEAD)"
@@ -124,3 +136,43 @@ jobs:
           name: hister-dmg
           path: build/Hister-*.dmg
           if-no-files-found: error
+
+      # PR-only: publish the unsigned .app as an artifact and drop a sticky
+      # comment on the PR pointing reviewers at the download.
+      - name: Upload artifact (PR)
+        id: pr_artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: hister-pr-${{ github.event.pull_request.number }}-${{ github.run_number }}
+          path: build/export/Hister.app
+          if-no-files-found: error
+
+      - name: Post download link on PR
+        if: github.event_name == 'pull_request' && success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          ARTIFACT_URL: ${{ steps.pr_artifact.outputs.artifact-url }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          MARKER="<!-- hister-ci-build-link -->"
+          BODY="${MARKER}
+          **Unsigned CI build ready** for commit \`${SHORT_SHA}\`.
+
+          [Download Hister.app (zipped)](${ARTIFACT_URL}) — or open the [run summary](${RUN_URL}) and grab it from the Artifacts section.
+
+          Because this build is ad-hoc signed, macOS Gatekeeper will refuse to open it. To try it locally: \`xattr -dr com.apple.quarantine ~/Downloads/Hister.app\` after unzipping."
+
+          # Find and update prior bot comment on this PR (identified by the
+          # HTML marker), or create a new one if none exists.
+          EXISTING=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+              --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"${MARKER}\")))][0].id")
+          if [[ -n "$EXISTING" && "$EXISTING" != "null" ]]; then
+              gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" -f body="$BODY" > /dev/null
+          else
+              gh pr comment "$PR" --body "$BODY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,13 +139,26 @@ jobs:
 
       # PR-only: publish the unsigned .app as an artifact and drop a sticky
       # comment on the PR pointing reviewers at the download.
+      #
+      # Stage into a dedicated dir so the artifact zip preserves the
+      # `Hister.app/` wrapper directory. If we pointed upload-artifact at
+      # Hister.app itself, the .app's contents would land at the artifact
+      # root (Contents/, Frameworks/, ...) and macOS wouldn't recognise the
+      # unzipped tree as an app bundle.
+      - name: Stage PR artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p build/pr-artifact
+          cp -R build/export/Hister.app build/pr-artifact/
+
       - name: Upload artifact (PR)
         id: pr_artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: hister-pr-${{ github.event.pull_request.number }}-${{ github.run_number }}
-          path: build/export/Hister.app
+          path: build/pr-artifact
           if-no-files-found: error
 
       - name: Post download link on PR
@@ -160,6 +173,12 @@ jobs:
           set -euo pipefail
           SHORT_SHA="${COMMIT_SHA:0:7}"
           MARKER="<!-- hister-ci-build-link -->"
+          # artifact-url is the browser page (…/artifacts/<id>). The API zip
+          # endpoint lives at /repos/…/actions/artifacts/<id>/zip and requires
+          # auth, so the curl below uses `gh auth token`.
+          ARTIFACT_ID="${ARTIFACT_URL##*/}"
+          ONELINER="curl -sL -H \"Authorization: Bearer \$(gh auth token)\" \"https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip\" -o /tmp/hister.zip && unzip -qo /tmp/hister.zip -d /tmp/hister && xattr -dr com.apple.quarantine /tmp/hister/Hister.app && open /tmp/hister/Hister.app"
+
           # Build the comment body line-by-line so YAML block-scalar indentation
           # can't bleed into the rendered markdown.
           BODY=$(printf '%s\n' \
@@ -168,10 +187,16 @@ jobs:
               "" \
               "[Download Hister.app (zipped)](${ARTIFACT_URL}) — or open the [run summary](${RUN_URL}) and grab it from the Artifacts section." \
               "" \
-              "Because this build is ad-hoc signed, macOS Gatekeeper will refuse to open it. After unzipping, strip the quarantine attribute:" \
+              "One-liner to download, unquarantine, and launch (requires \`gh auth login\` once):" \
               "" \
               '```sh' \
-              'xattr -dr com.apple.quarantine ~/Downloads/Hister.app' \
+              "${ONELINER}" \
+              '```' \
+              "" \
+              "Or if you already have the zip locally, just strip the quarantine attribute and open:" \
+              "" \
+              '```sh' \
+              'unzip -qo ~/Downloads/hister-pr-*.zip -d /tmp/hister && xattr -dr com.apple.quarantine /tmp/hister/Hister.app && open /tmp/hister/Hister.app' \
               '```')
 
           # Find and update prior bot comment on this PR (identified by the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,12 +160,19 @@ jobs:
           set -euo pipefail
           SHORT_SHA="${COMMIT_SHA:0:7}"
           MARKER="<!-- hister-ci-build-link -->"
-          BODY="${MARKER}
-          **Unsigned CI build ready** for commit \`${SHORT_SHA}\`.
-
-          [Download Hister.app (zipped)](${ARTIFACT_URL}) — or open the [run summary](${RUN_URL}) and grab it from the Artifacts section.
-
-          Because this build is ad-hoc signed, macOS Gatekeeper will refuse to open it. To try it locally: \`xattr -dr com.apple.quarantine ~/Downloads/Hister.app\` after unzipping."
+          # Build the comment body line-by-line so YAML block-scalar indentation
+          # can't bleed into the rendered markdown.
+          BODY=$(printf '%s\n' \
+              "${MARKER}" \
+              "**Unsigned CI build ready** for commit \`${SHORT_SHA}\`." \
+              "" \
+              "[Download Hister.app (zipped)](${ARTIFACT_URL}) — or open the [run summary](${RUN_URL}) and grab it from the Artifacts section." \
+              "" \
+              "Because this build is ad-hoc signed, macOS Gatekeeper will refuse to open it. After unzipping, strip the quarantine attribute:" \
+              "" \
+              '```sh' \
+              'xattr -dr com.apple.quarantine ~/Downloads/Hister.app' \
+              '```')
 
           # Find and update prior bot comment on this PR (identified by the
           # HTML marker), or create a new one if none exists.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       # Third-party actions pinned to full commit SHAs (defense against
       # tag-mutation / action-repo compromise). Version tags in comments; bump

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Environment knobs:
 - **Never commit `Safari/Hister.xcodeproj/` or `Safari/Hister Extension/Resources/`.** Both are gitignored and generated.
 - **CI actions are pinned to full commit SHAs** with the version tag in a trailing comment. See `.github/workflows/release.yml`. This is defense against tag-mutation / action-repo compromise. When bumping, resolve the SHA via `gh api /repos/<owner>/<repo>/git/refs/tags/<tag>`.
 - **Every push to `main` publishes a full release**, not a prerelease. Tag pushes (`vX.Y.Z`) use the tag as the version; branch pushes get a `v0.<day-of-year>.<h>.<m>` stamp. `workflow_dispatch` only uploads a build artifact, never a release.
-- **macOS 26.4 (Tahoe) is the deployment target** for the app; the extension target keeps `MACOSX_DEPLOYMENT_TARGET=10.14` as inherited from Apple's Safari extension template. Both are declared in `Safari/project.yml`.
+- **macOS 15 (Sequoia) is the deployment target** for the app; the extension target keeps `MACOSX_DEPLOYMENT_TARGET=10.14` as inherited from Apple's Safari extension template. Both are declared in `Safari/project.yml`.
 - **The wrapper adds no telemetry** and makes no network calls beyond what upstream Hister does. Keep it that way.
 
 ## Updating to a new upstream release

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Upstream source is never modified; the wrapper only patches the produced `dist/`
 
 ## Install (end users)
 
-Requires macOS 26.4 (Tahoe) or later, and a running [Hister server](https://github.com/asciimoo/hister) you can reach from your Mac.
+Requires macOS 15 (Sequoia) or later, and a running [Hister server](https://github.com/asciimoo/hister) you can reach from your Mac.
 
 Once a release is published:
 

--- a/Safari/project.yml
+++ b/Safari/project.yml
@@ -3,7 +3,7 @@ options:
   createIntermediateGroups: true
   defaultConfig: Release
   deploymentTarget:
-    macOS: "26.4"
+    macOS: "15.0"
   groupSortPosition: top
   generateEmptyDirectories: true
 
@@ -55,7 +55,7 @@ settings:
     GCC_WARN_UNUSED_FUNCTION: YES
     GCC_WARN_UNUSED_VARIABLE: YES
     LOCALIZATION_PREFERS_STRING_CATALOGS: YES
-    MACOSX_DEPLOYMENT_TARGET: "26.4"
+    MACOSX_DEPLOYMENT_TARGET: "15.0"
     MTL_FAST_MATH: YES
     SDKROOT: macosx
   configs:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -143,12 +143,24 @@ if [[ -n "${APPLE_TEAM_ID:-}" ]]; then
 fi
 xcodebuild "${XCODEBUILD_ARGS[@]}" archive
 
-echo "==> xcodebuild exportArchive"
-xcodebuild \
-    -exportArchive \
-    -archivePath build/Hister.xcarchive \
-    -exportOptionsPlist Safari/ExportOptions.plist \
-    -exportPath build/export
+# ExportOptions.plist mandates a Developer ID Application cert, which we
+# don't have in the keychain for ad-hoc builds (unsigned local dev, PR CI).
+# For those, skip exportArchive and pull the .app straight out of the
+# xcarchive instead. The archive itself already exercises the full compile
+# + link + embed-extension + sign path we care about verifying.
+mkdir -p build/export
+rm -rf build/export/Hister.app
+if [[ "$CODE_SIGN_IDENTITY" == "-" ]]; then
+    echo "==> Ad-hoc build; copying .app from xcarchive (skipping exportArchive)"
+    cp -R build/Hister.xcarchive/Products/Applications/Hister.app build/export/
+else
+    echo "==> xcodebuild exportArchive"
+    xcodebuild \
+        -exportArchive \
+        -archivePath build/Hister.xcarchive \
+        -exportOptionsPlist Safari/ExportOptions.plist \
+        -exportPath build/export
+fi
 
 if [[ "${NOTARIZE:-0}" == "1" ]]; then
     DMG="build/Hister-${DMG_VERSION}.dmg"


### PR DESCRIPTION
## Summary
- Drops the app's minimum macOS from Tahoe 26.4 (Xcode 17 default) to Sequoia 15.0 — nothing in the Swift sources requires Tahoe.
- Extension target keeps its historical 10.14 override.
- Release workflow pinned to `macos-15` for reproducible SDK selection during the first Sequoia-targeted build.

## Test plan
- [x] Regenerate xcodeproj from `Safari/project.yml` via xcodegen — clean.
- [x] Release build with `-configuration Release` — no `CLANG_WARN_UNGUARDED_AVAILABILITY` warnings.
- [x] Verified built `Hister.app/Contents/Info.plist` has `LSMinimumSystemVersion=15.0`; extension `.appex` stays at `10.14`.
- [x] Docs sweep for `26.4|Tahoe` — only remaining hit is `SFSafariWebExtensionConverterVersion` (intentional; scaffolding marker, not a runtime gate).
- [x] CI produces a signed+notarized DMG on the `macos-15` runner.
- [ ] Install the CI-built DMG on a real Sequoia machine (or VM), enable Hister in Safari > Settings > Extensions, load a page, watch for `SafariWebExtensionHandler` console errors.