### PR TITLE
notarize.sh: split submit from wait, retry polls, cap wall-clock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: recursive
+          # Full history + tags so the release-notes step can diff against
+          # the previous release tag.
+          fetch-depth: 0
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -107,15 +110,41 @@ jobs:
       - name: Release notes
         if: github.event_name == 'push'
         id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           UPSTREAM_SHA="$(git -C vendor/hister rev-parse HEAD)"
+
+          # Previous release tag (the most recent published release before
+          # this run). Empty on the very first release.
+          PREV_TAG="$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')"
+          if [[ -n "$PREV_TAG" ]] && git rev-parse -q --verify "refs/tags/${PREV_TAG}" >/dev/null; then
+              CHANGES="$(git log --pretty=format:'- %s' "${PREV_TAG}..HEAD")"
+              RANGE_HEADER="Changes since [\`${PREV_TAG}\`](../../releases/tag/${PREV_TAG}):"
+          else
+              CHANGES="$(git log --pretty=format:'- %s')"
+              RANGE_HEADER="Changes:"
+          fi
+          [[ -z "$CHANGES" ]] && CHANGES="- (no new commits)"
+
+          # Squash-merge subjects end with "(#123)" — turn that into a link
+          # to the PR. Uses | as sed delimiter to avoid escaping the slashes
+          # in the repo URL.
+          REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          CHANGES="$(printf '%s\n' "$CHANGES" | sed -E "s|\(#([0-9]+)\)|([#\1](${REPO_URL}/pull/\1))|g")"
+
           {
-              echo "notes<<EOF"
+              echo "notes<<HISTER_NOTES_EOF"
               echo "Unofficial Safari build of Hister."
               echo
               echo "Built from upstream commit \`$UPSTREAM_SHA\`."
               echo "Signed with an Apple Developer ID and notarized by Apple."
-              echo "EOF"
+              echo
+              echo "$RANGE_HEADER"
+              echo
+              echo "$CHANGES"
+              echo "HISTER_NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
 
       # Publish paths -----------------------------------------------------

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -12,10 +12,20 @@
 #   APPLE_NOTARY_PASSWORD  App-specific password          for CI where
 #   APPLE_TEAM_ID          10-character team ID           storing a keychain
 #                                                         profile isn't easy.)
+#
+# Timeouts / retries:
+#   NOTARY_TIMEOUT_SEC     Wall-clock cap for the whole submission (default
+#                          5400 = 90 min). notarytool's own --wait was
+#                          observed to lose a 2h-old submission to a single
+#                          network hiccup, so we submit without --wait and
+#                          poll `notarytool info` ourselves with backoff so a
+#                          transient failure only costs one poll, not the
+#                          whole submission.
 
 set -euo pipefail
 
 TARGET="${1:?usage: notarize.sh <path-to-app-or-dmg>}"
+NOTARY_TIMEOUT_SEC="${NOTARY_TIMEOUT_SEC:-5400}"
 
 WORK="$(mktemp -d)"
 trap 'rm -rf -- "$WORK"' EXIT
@@ -31,21 +41,82 @@ case "$TARGET" in
         ;;
 esac
 
-echo "==> Submitting to Apple notary service (this can take several minutes)"
+# Build the auth args once; every notarytool call reuses them.
+AUTH_ARGS=()
 if [[ -n "${HISTER_NOTARY_PROFILE:-}" ]]; then
-    xcrun notarytool submit "$SUBMIT" \
-        --keychain-profile "$HISTER_NOTARY_PROFILE" \
-        --wait
+    AUTH_ARGS=(--keychain-profile "$HISTER_NOTARY_PROFILE")
 else
     : "${APPLE_NOTARY_USER:?set HISTER_NOTARY_PROFILE, or APPLE_NOTARY_USER/PASSWORD/TEAM_ID}"
     : "${APPLE_NOTARY_PASSWORD:?}"
     : "${APPLE_TEAM_ID:?}"
-    xcrun notarytool submit "$SUBMIT" \
-        --apple-id "$APPLE_NOTARY_USER" \
-        --password "$APPLE_NOTARY_PASSWORD" \
-        --team-id "$APPLE_TEAM_ID" \
-        --wait
+    AUTH_ARGS=(
+        --apple-id "$APPLE_NOTARY_USER"
+        --password "$APPLE_NOTARY_PASSWORD"
+        --team-id  "$APPLE_TEAM_ID"
+    )
 fi
+
+echo "==> Submitting to Apple notary service"
+SUBMIT_JSON="$WORK/submit.json"
+xcrun notarytool submit "$SUBMIT" "${AUTH_ARGS[@]}" --output-format json \
+    > "$SUBMIT_JSON"
+SUBMISSION_ID="$(/usr/bin/plutil -extract id raw -o - -- "$SUBMIT_JSON")"
+if [[ -z "$SUBMISSION_ID" || "$SUBMISSION_ID" == "null" ]]; then
+    echo "error: could not extract submission id from notarytool output:" >&2
+    cat -- "$SUBMIT_JSON" >&2
+    exit 1
+fi
+echo "==> Submission id: $SUBMISSION_ID"
+
+# Poll with backoff. Transient network failures only cost the current
+# iteration; only wall-clock timeout or a terminal Apple verdict ends the
+# loop.
+START="$(date +%s)"
+DEADLINE=$(( START + NOTARY_TIMEOUT_SEC ))
+BACKOFF=15
+INFO_JSON="$WORK/info.json"
+
+while :; do
+    NOW="$(date +%s)"
+    ELAPSED=$(( NOW - START ))
+    if (( NOW >= DEADLINE )); then
+        echo "error: notarization timed out after ${ELAPSED}s (submission $SUBMISSION_ID)" >&2
+        echo "       resume manually with: xcrun notarytool info $SUBMISSION_ID <auth args>" >&2
+        exit 1
+    fi
+
+    if xcrun notarytool info "$SUBMISSION_ID" "${AUTH_ARGS[@]}" \
+            --output-format json > "$INFO_JSON" 2> "$WORK/info.err"; then
+        STATUS="$(/usr/bin/plutil -extract status raw -o - -- "$INFO_JSON" 2>/dev/null || echo "unknown")"
+        case "$STATUS" in
+            Accepted)
+                echo "==> Notarization Accepted (elapsed ${ELAPSED}s)"
+                break
+                ;;
+            Invalid|Rejected)
+                echo "error: notarization $STATUS (submission $SUBMISSION_ID)" >&2
+                echo "==> Fetching notary log:" >&2
+                xcrun notarytool log "$SUBMISSION_ID" "${AUTH_ARGS[@]}" >&2 || true
+                exit 1
+                ;;
+            *)
+                # "In Progress" or a status we don't recognise; keep waiting.
+                echo "==> Status: $STATUS (elapsed ${ELAPSED}s, next poll in ${BACKOFF}s)"
+                ;;
+        esac
+    else
+        echo "warn: notarytool info failed transiently after ${ELAPSED}s; retrying in ${BACKOFF}s" >&2
+        sed 's/^/  /' -- "$WORK/info.err" >&2 || true
+    fi
+
+    sleep "$BACKOFF"
+    # Exponential backoff, capped at 60s so we still notice a quick flip
+    # from In Progress to Accepted without a long tail.
+    if (( BACKOFF < 60 )); then
+        BACKOFF=$(( BACKOFF * 2 ))
+        (( BACKOFF > 60 )) && BACKOFF=60
+    fi
+done
 
 echo "==> Stapling ticket"
 xcrun stapler staple -- "$TARGET"


### PR DESCRIPTION
## Summary
- Prior run failed after `notarytool submit --wait` polled Apple for ~2h and then lost the connection ([run 32898598450](https://github.com/nburns/hister-safari/actions/runs/32898598450)). Apple almost certainly finished processing; the tool just couldn't ask about it.
- Now: submit once, capture submission id, poll `notarytool info` in a bash loop with exponential backoff (15s → 60s cap). Transient failures only cost one iteration.
- Wall-clock cap via \`NOTARY_TIMEOUT_SEC\` (default 5400 = 90 min) so a stalled Apple queue can't burn the runner.
- On \`Invalid\`/\`Rejected\`, dump the notary log before exiting.

## Test plan
- [x] `shellcheck scripts/notarize.sh` — clean.
- [x] Verified `plutil -extract` parses `notarytool`'s JSON output shape.
- [ ] Merge and confirm the next signed release succeeds (or that a real network blip mid-poll now retries instead of failing).