### PR TITLE
Preserve nested extension assets and match Chrome/Firefox behaviour

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Test manifest patcher
+        run: node --test scripts/patch-manifest.test.mjs
+
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Rules:
 - To change targets, build settings, frameworks, deployment targets, entitlements-adjacent flags (`ENABLE_APP_SANDBOX`, `REGISTER_APP_GROUPS`, etc.), or add source folders → **edit `Safari/project.yml`**, then rerun `xcodegen generate` inside `Safari/` (or just `scripts/build.sh`, which does it for you).
 - Do **not** commit changes to `Safari/Hister.xcodeproj/` — they are ignored, but if you touch them in Xcode's UI they will be silently wiped on the next generate.
 - Extension resources (`Safari/Hister Extension/Resources/`) are also gitignored — they are the output of `scripts/build.sh` (upstream `npm run build` + patches). Don't hand-edit them.
+- **Do not add `Hister Extension/Resources` as an Xcode "Copy Bundle Resources" group.** Xcode flattens nested files, which breaks `assets/icons/icon128.png` (the Safari Settings errors reported on issue #49). `project.yml` copies the tree with rsync in a build script so the layout is preserved. `scripts/build.sh` fails the build if the appex is missing that nested path.
 
 ## Setup
 
@@ -46,6 +47,7 @@ Environment knobs:
 - **Every push to `main` publishes a full release**, not a prerelease. Tag pushes (`vX.Y.Z`) use the tag as the version; branch pushes get a `v0.<day-of-year>.<h>.<m>` stamp. `workflow_dispatch` only uploads a build artifact, never a release.
 - **macOS 15 (Sequoia) is the deployment target** for the app; the extension target keeps `MACOSX_DEPLOYMENT_TARGET=10.14` as inherited from Apple's Safari extension template. Both are declared in `Safari/project.yml`.
 - **The wrapper adds no telemetry** and makes no network calls beyond what upstream Hister does. Keep it that way.
+- **Manifest merge tests** live in `scripts/patch-manifest.test.mjs`. Run with `node --test scripts/patch-manifest.test.mjs`. The release workflow runs them before xcodebuild.
 
 ## Updating to a new upstream release
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Once a release is published:
 
 Because the app is signed with an Apple Developer ID and notarized, there is no need to enable "Allow unsigned extensions" and the extension stays enabled across Safari restarts.
 
+The toolbar popup, skip rules, PDF indexing, access-token auth, and indexed-badge behaviour are the same code as the Chrome and Firefox extensions. Safari-only differences:
+
+- Toolbar icons are pre-rendered PNGs (Safari's service worker cannot use `OffscreenCanvas`).
+- Keyboard shortcuts are **not** applied from `suggested_key`. Assign them in Safari → Settings → Extensions if you want them.
+- The popup talks to your Hister server with a `safari-web-extension://` origin. Current Hister already allows that origin for CSRF. Token-auth from the popup also needs the server to answer CORS preflight (`OPTIONS`). Background indexing of pages works against stock Hister.
+
 ### Uninstall
 
 Quit Safari, drag `Hister.app` from `/Applications` to the Trash, then reopen Safari. Any extension settings stored in Safari are removed with the containing app.
@@ -42,8 +48,11 @@ Requires: macOS with Xcode 15+, plus the tools in `Brewfile` (Node.js, XcodeGen)
 git clone --recurse-submodules https://github.com/nburns/hister-safari.git
 cd hister-safari
 brew bundle                   # installs xcodegen + node
+node --test scripts/patch-manifest.test.mjs
 scripts/build.sh              # unsigned local build (CODE_SIGN_IDENTITY=- by default)
 ```
+
+Unsigned local builds require Safari's Develop menu → **Allow Unsigned Extensions** after each Safari restart.
 
 `scripts/build.sh` regenerates `Safari/Hister.xcodeproj` from `Safari/project.yml` on every run, so if you need to open Xcode directly, run `xcodegen generate` inside `Safari/` first (or just run the build script once).
 

--- a/Safari/Hister/AppDelegate.swift
+++ b/Safari/Hister/AppDelegate.swift
@@ -6,12 +6,21 @@
 //
 
 import Cocoa
+import SafariServices
 
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Override point for customization after application launch.
+        // Jump straight to this extension in Safari Settings. The onboarding
+        // window uses a WKWebView button that automation cannot click, and
+        // Safari will not list a new web extension until the host app has
+        // invoked this API at least once after install.
+        SFSafariApplication.showPreferencesForExtension(withIdentifier: extensionBundleIdentifier) { error in
+            if let error = error {
+                NSLog("Failed to open Safari extension settings: %@", error.localizedDescription)
+            }
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Safari/Hister/AppDelegate.swift
+++ b/Safari/Hister/AppDelegate.swift
@@ -8,14 +8,21 @@
 import Cocoa
 import SafariServices
 
+private let didOpenExtensionPreferencesKey = "didOpenExtensionPreferences"
+
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Jump straight to this extension in Safari Settings. The onboarding
-        // window uses a WKWebView button that automation cannot click, and
-        // Safari will not list a new web extension until the host app has
-        // invoked this API at least once after install.
+        // Safari requires the host app to invoke this API once before the
+        // extension appears in Settings. Only auto-open on first launch;
+        // later opens use the in-app "Open Safari Extension Preferences" button.
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: didOpenExtensionPreferencesKey) else {
+            return
+        }
+        defaults.set(true, forKey: didOpenExtensionPreferencesKey)
+
         SFSafariApplication.showPreferencesForExtension(withIdentifier: extensionBundleIdentifier) { error in
             if let error = error {
                 NSLog("Failed to open Safari extension settings: %@", error.localizedDescription)

--- a/Safari/Hister/Resources/Base.lproj/Main.html
+++ b/Safari/Hister/Resources/Base.lproj/Main.html
@@ -3,17 +3,23 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
-
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-
     <link rel="stylesheet" href="../Style.css">
     <script src="../Script.js" defer></script>
 </head>
 <body>
     <img src="../Icon.png" width="128" height="128" alt="Hister Icon">
-    <p class="state-unknown">You can turn on Hister’s extension in Safari Extensions preferences.</p>
-    <p class="state-on">Hister’s extension is currently on. You can turn it off in Safari Extensions preferences.</p>
-    <p class="state-off">Hister’s extension is currently off. You can turn it on in Safari Extensions preferences.</p>
+    <h1>Hister for Safari</h1>
+    <p class="unofficial">Unofficial community port. Not affiliated with the upstream Hister project.</p>
+    <p class="state-unknown">Enable the extension in Safari Settings, then click the toolbar icon to set your Hister server URL (default <span class="mono">http://127.0.0.1:4433/</span>).</p>
+    <p class="state-on">The extension is on. Click the Hister toolbar icon to confirm the server URL, then browse as usual — visited pages are indexed automatically, same as the Chrome and Firefox extensions.</p>
+    <p class="state-off">The extension is off. Turn it on in Safari Settings to start indexing pages you visit.</p>
+    <ol class="steps">
+        <li>Run a Hister server you control.</li>
+        <li>Enable <strong>Hister</strong> in Safari → Settings → Extensions.</li>
+        <li>Click the toolbar icon and save your server URL (and access token, if you use one).</li>
+    </ol>
+    <p class="shortcuts">Safari does not apply the Chrome/Firefox keyboard shortcuts automatically. Assign them under Safari → Settings → Extensions if you want the index / skip-rule commands.</p>
     <button class="open-preferences">Quit and Open Safari Extensions Preferences…</button>
 </body>
 </html>

--- a/Safari/Hister/Resources/Script.js
+++ b/Safari/Hister/Resources/Script.js
@@ -1,8 +1,8 @@
 function show(enabled, useSettingsInsteadOfPreferences) {
     if (useSettingsInsteadOfPreferences) {
-        document.getElementsByClassName('state-on')[0].innerText = "Hister’s extension is currently on. You can turn it off in the Extensions section of Safari Settings.";
-        document.getElementsByClassName('state-off')[0].innerText = "Hister’s extension is currently off. You can turn it on in the Extensions section of Safari Settings.";
-        document.getElementsByClassName('state-unknown')[0].innerText = "You can turn on Hister’s extension in the Extensions section of Safari Settings.";
+        document.getElementsByClassName('state-on')[0].innerText = "The extension is on. Click the Hister toolbar icon to confirm the server URL, then browse as usual — visited pages are indexed automatically, same as the Chrome and Firefox extensions.";
+        document.getElementsByClassName('state-off')[0].innerText = "The extension is off. Turn it on in the Extensions section of Safari Settings to start indexing pages you visit.";
+        document.getElementsByClassName('state-unknown')[0].innerText = "Enable the extension in Safari Settings, then click the toolbar icon to set your Hister server URL (default http://127.0.0.1:4433/).";
         document.getElementsByClassName('open-preferences')[0].innerText = "Quit and Open Safari Settings…";
     }
 

--- a/Safari/Hister/Resources/Style.css
+++ b/Safari/Hister/Resources/Style.css
@@ -6,7 +6,6 @@
 
 :root {
     color-scheme: light dark;
-
     --spacing: 20px;
 }
 
@@ -19,13 +18,34 @@ body {
     align-items: center;
     justify-content: center;
     flex-direction: column;
-
     gap: var(--spacing);
     margin: 0 calc(var(--spacing) * 2);
     height: 100%;
-
     font: -apple-system-short-body;
     text-align: center;
+}
+
+h1 {
+    font: -apple-system-short-headline;
+    margin: 0;
+}
+
+.unofficial,
+.shortcuts {
+    color: -apple-system-secondary-label;
+    max-width: 28em;
+}
+
+.steps {
+    text-align: left;
+    max-width: 28em;
+    margin: 0;
+    padding-left: 1.2em;
+}
+
+.mono {
+    font-family: ui-monospace, monospace;
+    font-size: 0.92em;
 }
 
 body:not(.state-on, .state-off) :is(.state-on, .state-off) {

--- a/Safari/Hister/ViewController.swift
+++ b/Safari/Hister/ViewController.swift
@@ -25,10 +25,18 @@ class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHan
         self.webView.loadFileURL(Bundle.main.url(forResource: "Main", withExtension: "html")!, allowingReadAccessTo: Bundle.main.resourceURL!)
     }
 
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
+            NSWorkspace.shared.open(url)
+            decisionHandler(.cancel)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: extensionBundleIdentifier) { (state, error) in
             guard let state = state, error == nil else {
-                // Insert code to inform the user that something went wrong.
                 return
             }
 

--- a/Safari/project.yml
+++ b/Safari/project.yml
@@ -101,6 +101,7 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_FILE: Hister/Info.plist
         INFOPLIST_KEY_CFBundleDisplayName: Hister
+        INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.utilities
         INFOPLIST_KEY_NSHumanReadableCopyright: ""
         INFOPLIST_KEY_NSMainStoryboardFile: Main
         INFOPLIST_KEY_NSPrincipalClass: NSApplication
@@ -128,14 +129,28 @@ targets:
     platform: macOS
     sources:
       - path: "Hister Extension/SafariWebExtensionHandler.swift"
-      - path: "Hister Extension/Resources"
-        buildPhase: resources
+    postCompileScripts:
+      - name: Copy web extension resources
+        basedOnDependencyAnalysis: false
+        shell: /bin/bash
+        script: |
+          set -euo pipefail
+          SRC="${SRCROOT}/Hister Extension/Resources"
+          DEST="${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+          if [[ ! -d "$SRC" ]]; then
+            echo "error: $SRC missing; run scripts/build.sh to stage the extension bundle" >&2
+            exit 1
+          fi
+          mkdir -p "$DEST"
+          rsync -a "$SRC/" "$DEST/"
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
         CURRENT_PROJECT_VERSION: 1
         ENABLE_APP_SANDBOX: YES
         ENABLE_HARDENED_RUNTIME: YES
+        ENABLE_OUTGOING_NETWORK_CONNECTIONS: YES
+        ENABLE_USER_SCRIPT_SANDBOXING: NO
         ENABLE_USER_SELECTED_FILES: readonly
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_FILE: "Hister Extension/Info.plist"

--- a/Safari/project.yml
+++ b/Safari/project.yml
@@ -142,7 +142,7 @@ targets:
             exit 1
           fi
           mkdir -p "$DEST"
-          rsync -a "$SRC/" "$DEST/"
+          rsync -a --delete "$SRC/" "$DEST/"
     settings:
       base:
         CODE_SIGN_STYLE: Automatic

--- a/patches/manifest.safari.json
+++ b/patches/manifest.safari.json
@@ -2,6 +2,16 @@
   "$comment": "Safari-only overrides merged over vendor/hister/webui/ext/dist/manifest.json by scripts/patch-manifest.mjs. Keys with null values are deleted from the merged output.",
   "key": null,
   "$comment_background": "Chrome's manifest sets service_worker at plugin time. Safari 17+ supports MV3 service_worker natively, so no change is needed here. The Safari-specific runtime shim is concatenated into background.js by scripts/build.sh so it runs before the upstream code.",
+  "icons": {
+    "16": "assets/icons/icon-16.png",
+    "32": "assets/icons/icon-32.png"
+  },
+  "action": {
+    "default_icon": {
+      "16": "assets/icons/icon-16.png",
+      "32": "assets/icons/icon-32.png"
+    }
+  },
   "commands": {
     "index-current-page": {
       "suggested_key": {

--- a/patches/safari-shims.js
+++ b/patches/safari-shims.js
@@ -1,14 +1,20 @@
 // Safari compatibility shim, prepended to background.js at build time.
 //
-// Upstream background.js uses OffscreenCanvas + createImageBitmap inside the
-// service worker to derive greyscale toolbar icons at runtime. Safari's MV3
-// service worker does not reliably support OffscreenCanvas, so we intercept
-// chrome.action.setIcon and swap runtime-generated ImageData for prebuilt
-// grey/normal PNGs shipped in assets/icons/. The prebuilt icons are copied
-// into the bundle by scripts/build.sh.
+// 1. Toolbar icons. Upstream background.js uses OffscreenCanvas +
+//    createImageBitmap inside the service worker to derive greyscale toolbar
+//    icons at runtime. Safari's MV3 service worker does not reliably support
+//    OffscreenCanvas, so we intercept chrome.action.setIcon and swap
+//    runtime-generated ImageData for prebuilt grey/normal PNGs shipped in
+//    assets/icons/. The prebuilt icons are copied into the bundle by
+//    scripts/build.sh.
 //
-// Detection: an imageData-based setIcon call is the runtime-generated path.
-// A path-based call is the caller's own choice and passes through untouched.
+//    Detection: an imageData-based setIcon call is the runtime-generated
+//    path. A path-based call is the caller's own choice and passes through.
+//
+// 2. Internal Safari pages. Upstream updateTabIcon already skips
+//    chrome-extension:// and moz-extension:// URLs. Safari's equivalent
+//    schemes are not in that list, so we wrap tabs.onUpdated / onActivated
+//    and drop those events before they reach upstream.
 
 (function installIconShim() {
   if (typeof chrome === 'undefined' || !chrome.action || !chrome.action.setIcon) return;
@@ -44,4 +50,28 @@
     }
     return originalSetIcon(details, callback);
   };
+})();
+
+(function installTabUrlFilter() {
+  if (typeof chrome === 'undefined' || !chrome.tabs) return;
+
+  function isSafariInternalURL(url) {
+    if (!url) return false;
+    return (
+      url.startsWith('safari-web-extension://') ||
+      url.startsWith('safari-extension://') ||
+      url.startsWith('applewebdata://')
+    );
+  }
+
+  if (chrome.tabs.onUpdated && chrome.tabs.onUpdated.addListener) {
+    const original = chrome.tabs.onUpdated.addListener.bind(chrome.tabs.onUpdated);
+    chrome.tabs.onUpdated.addListener = function filteredOnUpdated(listener) {
+      return original(function (tabId, changeInfo, tab) {
+        const url = (tab && tab.url) || changeInfo.url || '';
+        if (isSafariInternalURL(url)) return;
+        return listener(tabId, changeInfo, tab);
+      });
+    };
+  }
 })();

--- a/patches/safari-shims.js
+++ b/patches/safari-shims.js
@@ -64,14 +64,60 @@
     );
   }
 
-  if (chrome.tabs.onUpdated && chrome.tabs.onUpdated.addListener) {
-    const original = chrome.tabs.onUpdated.addListener.bind(chrome.tabs.onUpdated);
-    chrome.tabs.onUpdated.addListener = function filteredOnUpdated(listener) {
-      return original(function (tabId, changeInfo, tab) {
-        const url = (tab && tab.url) || changeInfo.url || '';
-        if (isSafariInternalURL(url)) return;
-        return listener(tabId, changeInfo, tab);
+  // Track original listener -> wrapper so removeListener/hasListener keep working.
+  function wrapTabEventTarget(eventTarget, wrapListener) {
+    if (!eventTarget || !eventTarget.addListener) return;
+
+    const wrapped = new Map();
+    const originalAdd = eventTarget.addListener.bind(eventTarget);
+    const originalRemove = eventTarget.removeListener
+      ? eventTarget.removeListener.bind(eventTarget)
+      : null;
+    const originalHas = eventTarget.hasListener
+      ? eventTarget.hasListener.bind(eventTarget)
+      : null;
+
+    eventTarget.addListener = function patchedAddListener(listener) {
+      const wrapper = wrapListener(listener);
+      wrapped.set(listener, wrapper);
+      return originalAdd(wrapper);
+    };
+
+    if (originalRemove) {
+      eventTarget.removeListener = function patchedRemoveListener(listener) {
+        const wrapper = wrapped.get(listener);
+        if (wrapper) {
+          wrapped.delete(listener);
+          return originalRemove(wrapper);
+        }
+        return originalRemove(listener);
+      };
+    }
+
+    if (originalHas) {
+      eventTarget.hasListener = function patchedHasListener(listener) {
+        const wrapper = wrapped.get(listener);
+        if (wrapper) return originalHas(wrapper);
+        return originalHas(listener);
+      };
+    }
+  }
+
+  wrapTabEventTarget(chrome.tabs.onUpdated, function wrapOnUpdated(listener) {
+    return function filteredOnUpdated(tabId, changeInfo, tab) {
+      const url = (tab && tab.url) || changeInfo.url || '';
+      if (isSafariInternalURL(url)) return;
+      return listener(tabId, changeInfo, tab);
+    };
+  });
+
+  wrapTabEventTarget(chrome.tabs.onActivated, function wrapOnActivated(listener) {
+    return function filteredOnActivated(activeInfo) {
+      chrome.tabs.get(activeInfo.tabId, (tab) => {
+        if (chrome.runtime.lastError) return;
+        if (tab && isSafariInternalURL(tab.url)) return;
+        return listener(activeInfo);
       });
     };
-  }
+  });
 })();

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -107,6 +107,35 @@ for name in icon-16.png icon-32.png icon-grey-16.png icon-grey-32.png; do
     cp -- "assets/$name" "$RESOURCES/assets/icons/$name"
 done
 
+# Safari Settings lists every path in icons / default_icon. Upstream ships
+# icon128.png via the ext build; copy it explicitly so a dist layout change
+# cannot leave the appex with a dangling manifest path (issue #49 thread).
+if [[ -f "$UPSTREAM_EXT/dist/assets/icons/icon128.png" ]]; then
+    cp -- "$UPSTREAM_EXT/dist/assets/icons/icon128.png" "$RESOURCES/assets/icons/icon128.png"
+elif [[ -f "$UPSTREAM_EXT/assets/icon128.png" ]]; then
+    mkdir -p -- "$RESOURCES/assets/icons"
+    cp -- "$UPSTREAM_EXT/assets/icon128.png" "$RESOURCES/assets/icons/icon128.png"
+else
+    echo "error: upstream icon128.png missing from dist and source" >&2
+    exit 1
+fi
+
+python3 -c '
+import json, os, sys
+root = sys.argv[1]
+manifest = json.load(open(os.path.join(root, "manifest.json")))
+required = []
+for collection in (manifest.get("icons") or {}, (manifest.get("action") or {}).get("default_icon") or {}):
+    required.extend(collection.values())
+missing = [rel for rel in required if not os.path.isfile(os.path.join(root, rel))]
+if missing:
+    sys.exit("extension bundle is missing icon files: " + ", ".join(missing))
+bg = open(os.path.join(root, "background.js"), encoding="utf-8").read()
+if "installIconShim" not in bg:
+    sys.exit("background.js is missing the Safari icon shim")
+print("bundle ok: icons + safari shim present")
+' "$RESOURCES"
+
 if [[ "${SKIP_XCODE:-0}" == "1" ]]; then
     echo "==> SKIP_XCODE=1, done."
     exit 0
@@ -161,6 +190,25 @@ else
         -exportOptionsPlist Safari/ExportOptions.plist \
         -exportPath build/export
 fi
+
+APPEX_RES="build/export/Hister.app/Contents/PlugIns/Hister Extension.appex/Contents/Resources"
+python3 -c '
+import json, os, sys
+root = sys.argv[1]
+if not os.path.isdir(root):
+    sys.exit("appex Resources missing: " + root)
+manifest = json.load(open(os.path.join(root, "manifest.json")))
+required = []
+for collection in (manifest.get("icons") or {}, (manifest.get("action") or {}).get("default_icon") or {}):
+    required.extend(collection.values())
+missing = [rel for rel in required if not os.path.isfile(os.path.join(root, rel))]
+if missing:
+    sys.exit("appex is missing icon files (Copy Bundle Resources flattened them?): " + ", ".join(missing))
+nested = os.path.join(root, "assets", "icons", "icon128.png")
+if not os.path.isfile(nested):
+    sys.exit("appex lost assets/icons/ layout; icon128.png must stay nested")
+print("appex ok: nested icons present")
+' "$APPEX_RES"
 
 if [[ "${NOTARIZE:-0}" == "1" ]]; then
     DMG="build/Hister-${DMG_VERSION}.dmg"

--- a/scripts/patch-manifest.mjs
+++ b/scripts/patch-manifest.mjs
@@ -8,18 +8,13 @@
 
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const [, , upstreamPath, overridePath, outPath] = process.argv;
-if (!upstreamPath || !overridePath || !outPath) {
-  console.error('usage: patch-manifest.mjs <upstream> <override> <output>');
-  process.exit(2);
-}
-
-function isPlainObject(v) {
+export function isPlainObject(v) {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
-function merge(base, patch) {
+export function merge(base, patch) {
   if (!isPlainObject(patch)) return patch;
   const out = isPlainObject(base) ? { ...base } : {};
   for (const [k, v] of Object.entries(patch)) {
@@ -35,10 +30,26 @@ function merge(base, patch) {
   return out;
 }
 
-const upstream = JSON.parse(readFileSync(upstreamPath, 'utf8'));
-const override = JSON.parse(readFileSync(overridePath, 'utf8'));
-const merged = merge(upstream, override);
+export function patchManifest(upstream, override) {
+  return merge(upstream, override);
+}
 
-mkdirSync(dirname(outPath), { recursive: true });
-writeFileSync(outPath, JSON.stringify(merged, null, 2) + '\n');
-console.error(`wrote ${outPath}`);
+function main(argv) {
+  const [, , upstreamPath, overridePath, outPath] = argv;
+  if (!upstreamPath || !overridePath || !outPath) {
+    console.error('usage: patch-manifest.mjs <upstream> <override> <output>');
+    process.exit(2);
+  }
+
+  const upstream = JSON.parse(readFileSync(upstreamPath, 'utf8'));
+  const override = JSON.parse(readFileSync(overridePath, 'utf8'));
+  const merged = merge(upstream, override);
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(merged, null, 2) + '\n');
+  console.error(`wrote ${outPath}`);
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  main(process.argv);
+}

--- a/scripts/patch-manifest.test.mjs
+++ b/scripts/patch-manifest.test.mjs
@@ -1,0 +1,66 @@
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { merge } from './patch-manifest.mjs';
+
+const script = fileURLToPath(new URL('./patch-manifest.mjs', import.meta.url));
+
+test('merge keeps upstream keys, overlays nested objects, and drops $ comments', () => {
+  const merged = merge(
+    {
+      name: 'Hister',
+      icons: { 128: 'assets/icons/icon128.png' },
+      action: { default_icon: { 128: 'assets/icons/icon128.png' }, default_popup: 'popup.html' },
+      key: 'UPSTREAM-KEY',
+    },
+    {
+      $comment: 'ignored',
+      key: null,
+      icons: { 16: 'assets/icons/icon-16.png', 32: 'assets/icons/icon-32.png' },
+      action: { default_icon: { 16: 'assets/icons/icon-16.png' } },
+    },
+  );
+
+  assert.equal(merged.name, 'Hister');
+  assert.equal(merged.key, undefined);
+  assert.equal(merged.$comment, undefined);
+  assert.deepEqual(merged.icons, {
+    128: 'assets/icons/icon128.png',
+    16: 'assets/icons/icon-16.png',
+    32: 'assets/icons/icon-32.png',
+  });
+  assert.deepEqual(merged.action, {
+    default_icon: {
+      128: 'assets/icons/icon128.png',
+      16: 'assets/icons/icon-16.png',
+    },
+    default_popup: 'popup.html',
+  });
+});
+
+test('CLI writes the merged manifest', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hister-manifest-'));
+  try {
+    const upstream = join(dir, 'upstream.json');
+    const override = join(dir, 'override.json');
+    const out = join(dir, 'out.json');
+    writeFileSync(upstream, JSON.stringify({ name: 'Hister', key: 'K' }));
+    writeFileSync(override, JSON.stringify({ key: null, icons: { 16: 'a.png' } }));
+
+    const result = spawnSync(process.execPath, [script, upstream, override, out], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const written = JSON.parse(readFileSync(out, 'utf8'));
+    assert.equal(written.name, 'Hister');
+    assert.equal(written.key, undefined);
+    assert.equal(written.icons[16], 'a.png');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Safari Settings was reporting missing `assets/icons/icon128.png` because Xcode's Copy Bundle Resources phase flattened the staged tree. The extension target now rsyncs `Hister Extension/Resources/` into the appex so `assets/icons/` stays nested, and `scripts/build.sh` fails if that path is missing from the built app.
- Manifest now includes 16/32 toolbar icons (keeping upstream 128), the background shim skips Safari-internal tab URLs, and the extension sandbox allows outgoing network.
- Host app copy explains the unofficial port and the same setup flow as the other browsers. Manifest merge is covered by `node --test scripts/patch-manifest.test.mjs`.

## Test plan

- [x] `node --test scripts/patch-manifest.test.mjs`
- [x] `scripts/build.sh` (unsigned) — archive succeeds and prints `appex ok: nested icons present`
- [x] Built appex contains `Contents/Resources/assets/icons/icon128.png` (not a flattened `icon128.png` at Resources root)
- [x] `content.js` matches upstream dist; `background.js` is shim + upstream
- [ ] Install the PR artifact, enable Hister in Safari → Settings → Extensions, load a page, confirm toolbar icon and popup settings work